### PR TITLE
Fix bug in download

### DIFF
--- a/download-ldc-corpora
+++ b/download-ldc-corpora
@@ -185,7 +185,7 @@ for LDC_CORPUS in "$@" ; do
 
     echo
 
-    TSV_LINE=$(grep "${LDC_CORPUS}" ${DOWNLOAD_FILE})
+    TSV_LINE=$(grep -P "${LDC_CORPUS}\t" ${DOWNLOAD_FILE})
     CORPUS_URL=$(cut  -f 5 <<< "${TSV_LINE}")
     CORPUS_NAME=$(cut -f 2 <<< "${TSV_LINE}" | tr ' ' '_')
     CORPUS_FILE=$(cut -f 6 <<< "${TSV_LINE}" | sed 's,<br/>.*,,; s,.tgz$,,')


### PR DESCRIPTION
The current `grep` only checks for the prefix; hence, if it has the same prefix, multiple rows are grepped, hence failing to download.
For example,
- `LDC93S1`: TIMIT dataset
- `LDC93S10`: TIDIGITS dataset
Both dataset gets grepped. Simple fix is to also grep the following \t.
Note that all the dataset tags start with LDC, so we don't need to take care about the prefix.